### PR TITLE
Disabled caching of redirect.

### DIFF
--- a/customization/src/redirect.html.schema
+++ b/customization/src/redirect.html.schema
@@ -1,6 +1,9 @@
 <html>
 <head><title>Redirect...</title>
 <meta http-equiv="refresh" content="0;url=http://#####HOST#####/content" />
+<meta http-equiv='cache-control' content='no-cache, no-store, must-revalidate' />
+<meta http-equiv='pragma' content='no-cache' />
+<meta http-equiv='expires' content='0' />
 </head>
 <body>
 <img src="/vc_counter.php" />Redirect...


### PR DESCRIPTION
Copied those parameters from the redirect.html.

To reproduce the failure:
I was connected to the wifi, headed to m.spiegel.de with chrome on android and I was redirected to the box. After I've left the wifi, I tried to connect to m.spiegel.de again, but it had cached the redirect and tried to open the box-url again.

I've not tested this, because I've no box...
